### PR TITLE
Remove relative_datetime activity

### DIFF
--- a/datetime/tool.py
+++ b/datetime/tool.py
@@ -17,34 +17,6 @@ class DateTimeTool(BaseTool):
         except Exception as e:
             return ErrorArtifact(f"error getting current datetime: {e}")
 
-    @activity(
-        config={
-            "description": "Can be used to return a relative date and time.",
-            "schema": Schema(
-                {
-                    Literal(
-                        "relative_date_string",
-                        description='Relative date in English. For example, "now EST", "20 minutes ago", '
-                        '"in 2 days", "3 months, 1 week and 1 day ago", or "yesterday at 2pm"',
-                    ): str,
-                },
-            ),
-        },
-    )
-    def get_relative_datetime(self, params: dict) -> BaseArtifact:
-        from dateparser import parse
-
-        try:
-            date_string = params["values"]["relative_date_string"]
-            relative_datetime = parse(date_string)
-
-            if relative_datetime:
-                return TextArtifact(str(relative_datetime))
-            else:
-                return ErrorArtifact("invalid date string")
-        except Exception as e:
-            return ErrorArtifact(f"error getting current datetime: {e}")
-
 
 def init_tool() -> BaseTool:
     return DateTimeTool()


### PR DESCRIPTION
this activity is finicky because its expecting a specific format. LLMs can generally figure out date math when given the current time, so the current time activity should be sufficient